### PR TITLE
remove lifetime from instruction

### DIFF
--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -3,28 +3,25 @@ pub mod val;
 use crate::memory::*;
 use crate::stack::*;
 use error::InstructionError;
-use z3::ast::Bool;
 
 pub type InstructionResult<T> = Result<T, InstructionError>;
-pub struct ExecRecord<'a, S, M>
+pub struct ExecRecord<S, M>
 where
     M: WriteableMem,
     S: Stack,
 {
     pub stack_diff: Option<StackRecord<S>>,
     pub mem_diff: Option<MemRecord<M>>,
-    // Each inner vec represents a new path in the program
-    pub path_constraints: Vec<Vec<Bool<'a>>>,
     pub pc_change: Option<usize>,
     pub halt: bool,
 }
 
-pub trait VMInstruction<'a> {
+pub trait VMInstruction {
     type ValStack: Stack;
     type Mem: RWMem;
     fn exec(
         &self,
         stack: &Self::ValStack,
         memory: &Self::Mem,
-    ) -> InstructionResult<ExecRecord<'a, Self::ValStack, Self::Mem>>;
+    ) -> InstructionResult<ExecRecord<Self::ValStack, Self::Mem>>;
 }

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -25,7 +25,7 @@ pub struct BaseMachine<'a, Mem, MachineStack, I, MemIdx, MemVal, StackVal>
 where
     Mem: RWMem + ReadOnlyMem<Index = MemIdx, MemVal = MemVal>,
     MachineStack: Stack<StackVal = StackVal>,
-    I: VMInstruction<'a, Mem = Mem, ValStack = MachineStack>,
+    I: VMInstruction<Mem = Mem, ValStack = MachineStack>,
     StackVal: Into<MemIdx> + Into<MemVal>,
 {
     mem: Mem,
@@ -40,7 +40,7 @@ impl<'a, Mem, MachineStack, I, MemIdx, MemVal, StackVal>
 where
     Mem: RWMem + ReadOnlyMem<Index = MemIdx, MemVal = MemVal> + std::fmt::Debug + Clone,
     MachineStack: Stack<StackVal = StackVal> + std::fmt::Debug + Clone,
-    I: VMInstruction<'a, Mem = Mem, ValStack = MachineStack>,
+    I: VMInstruction<Mem = Mem, ValStack = MachineStack>,
     StackVal: Into<MemIdx> + Into<MemVal>,
 {
     pub fn new(stack: MachineStack, mem_init: Mem::InitArgs) -> Self {
@@ -81,7 +81,7 @@ where
         ) {
             for inst in &pgm[pc.clone()..] {
                 let rec = inst.exec(&stack, &mem).unwrap();
-                println!("EXEC RECORD CONSTRAINTS: {:?}", rec.path_constraints);
+
                 if rec.halt || pc.clone() == pgm.len() {
                     return (None, None);
                 } else {
@@ -103,33 +103,6 @@ where
                         }
                     };
 
-                    if rec.path_constraints.len() == 1 {
-                        let curr_path_constraints = rec.path_constraints.first().cloned().unwrap();
-                        return (
-                            Some((
-                                pc.clone() + 1,
-                                stack.clone(),
-                                mem.clone(),
-                                curr_path_constraints,
-                            )),
-                            None,
-                        );
-                    }
-
-                    if rec.path_constraints.len() == 2 {
-                        let branch_one_rules = rec.path_constraints.first().cloned().unwrap();
-                        let branch_two_rules = rec.path_constraints.get(1).cloned().unwrap();
-
-                        return (
-                            Some((pc.clone() + 1, stack.clone(), mem.clone(), branch_one_rules)),
-                            Some((
-                                rec.pc_change.unwrap(),
-                                stack.clone(),
-                                mem.clone(),
-                                branch_two_rules,
-                            )),
-                        );
-                    }
                     return (
                         Some((pc.clone() + 1, stack.clone(), mem.clone(), vec![])),
                         None,
@@ -235,7 +208,7 @@ impl<'a, MachineStack, I>
     BaseMachine<'a, MemIntToInt<'a>, MachineStack, I, Int<'a>, Int<'a>, Int<'a>>
 where
     MachineStack: Stack<StackVal = Int<'a>>,
-    I: VMInstruction<'a, Mem = MemIntToInt<'a>, ValStack = MachineStack>,
+    I: VMInstruction<Mem = MemIntToInt<'a>, ValStack = MachineStack>,
 {
     // For symbolic memory
     pub fn new_with_ctx(stack: MachineStack, mem_init_args: Rc<&'a Context>) -> Self {

--- a/tests/simple_lang.rs
+++ b/tests/simple_lang.rs
@@ -21,7 +21,7 @@ pub enum Instruction<T> {
     STOP,
 }
 
-impl<'a> VMInstruction<'a> for Instruction<Int<'a>> {
+impl<'a> VMInstruction for Instruction<Int<'a>> {
     type ValStack = BaseStack<Int<'a>>;
 
     type Mem = MemIntToInt<'a>;
@@ -30,11 +30,10 @@ impl<'a> VMInstruction<'a> for Instruction<Int<'a>> {
         &self,
         stack: &Self::ValStack,
         memory: &Self::Mem,
-    ) -> InstructionResult<ExecRecord<'a, Self::ValStack, Self::Mem>> {
-        let mut change_log: ExecRecord<'a, Self::ValStack, Self::Mem> = ExecRecord {
+    ) -> InstructionResult<ExecRecord<Self::ValStack, Self::Mem>> {
+        let mut change_log: ExecRecord<Self::ValStack, Self::Mem> = ExecRecord {
             stack_diff: None,
             mem_diff: None,
-            path_constraints: vec![],
             pc_change: None,
             halt: false,
         };
@@ -69,9 +68,7 @@ impl<'a> VMInstruction<'a> for Instruction<Int<'a>> {
                 });
             }
             Instruction::Assert(v) => {
-                let stack_top = stack.peek::<Int<'a>>(0).unwrap();
-                let constraint = stack_top._eq(v);
-                change_log.path_constraints.push(vec![constraint]);
+                todo!()
             }
             Instruction::MLOAD => {
                 let mem_offset = stack.peek::<Int<'a>>(0).unwrap();
@@ -119,17 +116,7 @@ impl<'a> VMInstruction<'a> for Instruction<Int<'a>> {
                 });
             }
             Instruction::JUMPI => {
-                let dest = stack.peek::<Int<'a>>(0).unwrap();
-                let ctx = dest.ctx;
-                let cond = stack.peek::<Int<'a>>(1).unwrap();
-                if let Some(dest) = dest.as_u64() {
-                    let zero = Int::from_u64(ctx, 0);
-                    change_log.path_constraints.push(vec![cond._eq(&zero)]);
-                    change_log
-                        .path_constraints
-                        .push(vec![Bool::not(&cond._eq(&zero))]);
-                    change_log.pc_change = Some(dest as usize);
-                }
+                todo!()
             }
             Instruction::STOP => {
                 change_log.halt = true;


### PR DESCRIPTION
path constraints are the only part of the VMInstruction interface that require the Z3 lifetime context. 

We can temporarily remove the code dealing with path constraints. When we add them back, we can add them back to a separate "symbolic instruction". 

See here with type parameter `C` which can be completely abstract on the `SymbolicVMInstruction` trait and be specified to be the result of "constraining" the stack value in the actual symbolic op.

https://github.com/WilfredTA/symbolic-stack-machines/blob/aec8aa99c2c0c19370f8402c3976a41300ed8f70/src/instructions/mod.rs#L18-L57

https://github.com/WilfredTA/symbolic-stack-machines/blob/aec8aa99c2c0c19370f8402c3976a41300ed8f70/src/instructions/sym.rs

Ultimately, the type constraints for the constraint trait will involve more of the machine than just the stack value but this is sufficient for our current usage. 