### PR TITLE
Made return type for AbstractInstruction abstract; Separated Abstract…

### DIFF
--- a/contrib/src/instructions/arith.rs
+++ b/contrib/src/instructions/arith.rs
@@ -1,27 +1,33 @@
 use symbolic_stack_machines_core::{
-    constraint::Constraint,
-    instructions::{AbstractExecRecord, AbstractInstruction, EnvExtension, InstructionResult},
+    instructions::{
+        AbstractExecRecord, AbstractInstruction, ConcreteAbstractExecRecord, EnvExtension,
+        InstructionResult,
+    },
     memory::Mem,
     stack::{Stack, StackOpRecord, StackRecord},
 };
 
 pub struct ADD;
 
-impl<T, S, M, Extension, ReturnRecord, C> AbstractInstruction<S, M, Extension, ReturnRecord, C>
-    for ADD
+impl<T, S, M, Extension>
+    AbstractInstruction<
+        S,
+        M,
+        Extension,
+        ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>,
+    > for ADD
 where
     T: std::ops::Add + std::ops::Add<Output = T> + Clone,
     S: Stack<StackVal = T>,
     M: Mem,
     Extension: EnvExtension,
-    C: Into<Constraint<C>>,
 {
     fn exec(
         &self,
         stack: &S,
         _mem: &M,
         _ext: &Extension,
-    ) -> InstructionResult<AbstractExecRecord<S, M, Extension::DiffRecordType, C>> {
+    ) -> InstructionResult<ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>> {
         let mut change_log = AbstractExecRecord::default();
 
         let op_1: T = stack.peek(0).unwrap();
@@ -42,21 +48,25 @@ where
 
 pub struct SUB;
 
-impl<T, S, M, Extension, ReturnRecord, C> AbstractInstruction<S, M, Extension, ReturnRecord, C>
-    for SUB
+impl<T, S, M, Extension>
+    AbstractInstruction<
+        S,
+        M,
+        Extension,
+        ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>,
+    > for SUB
 where
     T: std::ops::Sub + std::ops::Sub<Output = T> + Clone,
     S: Stack<StackVal = T>,
     M: Mem,
     Extension: EnvExtension,
-    C: Into<Constraint<C>>,
 {
     fn exec(
         &self,
         stack: &S,
         _mem: &M,
         _ext: &Extension,
-    ) -> InstructionResult<AbstractExecRecord<S, M, Extension::DiffRecordType, C>> {
+    ) -> InstructionResult<ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>> {
         let mut change_log = AbstractExecRecord::default();
 
         let op_1: T = stack.peek(0).unwrap();

--- a/contrib/src/instructions/bitwise.rs
+++ b/contrib/src/instructions/bitwise.rs
@@ -1,6 +1,8 @@
 use symbolic_stack_machines_core::{
-    constraint::Constraint,
-    instructions::{AbstractExecRecord, AbstractInstruction, EnvExtension, InstructionResult},
+    instructions::{
+        AbstractExecRecord, AbstractInstruction, ConcreteAbstractExecRecord, EnvExtension,
+        InstructionResult,
+    },
     memory::Mem,
     stack::{Stack, StackOpRecord, StackRecord},
 };
@@ -20,21 +22,25 @@ pub trait MachineEq {
 
 pub struct ISZERO;
 
-impl<T, S, M, Extension, ReturnRecord, C> AbstractInstruction<S, M, Extension, ReturnRecord, C>
-    for ISZERO
+impl<T, S, M, Extension>
+    AbstractInstruction<
+        S,
+        M,
+        Extension,
+        ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>,
+    > for ISZERO
 where
     T: From<u8> + MachineEq,
     S: Stack<StackVal = T>,
     M: Mem,
     Extension: EnvExtension,
-    C: Into<Constraint<C>>,
 {
     fn exec(
         &self,
         stack: &S,
         _memory: &M,
         _ext: &Extension,
-    ) -> InstructionResult<AbstractExecRecord<S, M, Extension::DiffRecordType, C>> {
+    ) -> InstructionResult<ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>> {
         let mut change_log = AbstractExecRecord::default();
 
         let op: T = stack.peek(0).unwrap();

--- a/contrib/src/instructions/misc.rs
+++ b/contrib/src/instructions/misc.rs
@@ -1,27 +1,33 @@
 use symbolic_stack_machines_core::{
-    constraint::Constraint,
-    instructions::{AbstractExecRecord, AbstractInstruction, EnvExtension, InstructionResult},
+    instructions::{
+        AbstractExecRecord, AbstractInstruction, ConcreteAbstractExecRecord, EnvExtension,
+        InstructionResult,
+    },
     memory::{Mem, MemOpRecord, MemRecord, ReadOnlyMem, WriteableMem},
     stack::{Stack, StackOpRecord, StackRecord},
 };
 
 pub struct PUSH<T>(pub T);
 
-impl<T, S, M, Extension, ReturnRecord, C> AbstractInstruction<S, M, Extension, ReturnRecord, C>
-    for PUSH<T>
+impl<T, S, M, Extension>
+    AbstractInstruction<
+        S,
+        M,
+        Extension,
+        ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>,
+    > for PUSH<T>
 where
     T: Clone + std::fmt::Debug,
     S: Stack<StackVal = T>,
     M: Mem,
     Extension: EnvExtension,
-    C: Into<Constraint<C>>,
 {
     fn exec(
         &self,
         _stack: &S,
         _memory: &M,
         _ext: &Extension,
-    ) -> InstructionResult<AbstractExecRecord<S, M, Extension::DiffRecordType, C>> {
+    ) -> InstructionResult<ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>> {
         let mut change_log = AbstractExecRecord::default();
 
         change_log.stack_diff = Some(StackRecord {
@@ -34,20 +40,24 @@ where
 
 pub struct STOP;
 
-impl<S, M, Extension, ReturnRecord, C> AbstractInstruction<S, M, Extension, ReturnRecord, C>
-    for STOP
+impl<S, M, Extension>
+    AbstractInstruction<
+        S,
+        M,
+        Extension,
+        ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>,
+    > for STOP
 where
     S: Stack,
     M: Mem,
     Extension: EnvExtension,
-    C: Into<Constraint<C>>,
 {
     fn exec(
         &self,
         _stack: &S,
         _memory: &M,
         _ext: &Extension,
-    ) -> InstructionResult<AbstractExecRecord<S, M, Extension::DiffRecordType, C>> {
+    ) -> InstructionResult<ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>> {
         let mut change_log = AbstractExecRecord::default();
 
         change_log.halt = true;
@@ -58,22 +68,26 @@ where
 
 pub struct JUMPI;
 
-impl<T, S, M, Extension, ReturnRecord, C> AbstractInstruction<S, M, Extension, ReturnRecord, C>
-    for JUMPI
+impl<T, S, M, Extension>
+    AbstractInstruction<
+        S,
+        M,
+        Extension,
+        ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>,
+    > for JUMPI
 where
     T: From<u8> + Eq + TryInto<usize>,
     S: Stack<StackVal = T>,
     M: Mem,
     <T as TryInto<usize>>::Error: std::fmt::Debug,
     Extension: EnvExtension,
-    C: Into<Constraint<C>>,
 {
     fn exec(
         &self,
         stack: &S,
         _memory: &M,
         _ext: &Extension,
-    ) -> InstructionResult<AbstractExecRecord<S, M, Extension::DiffRecordType, C>> {
+    ) -> InstructionResult<ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>> {
         let mut change_log = AbstractExecRecord::default();
 
         let dest: T = stack.peek(0).unwrap();
@@ -90,21 +104,25 @@ where
 
 pub struct MLOAD;
 
-impl<T, S, M, Extension, ReturnRecord, C> AbstractInstruction<S, M, Extension, ReturnRecord, C>
-    for MLOAD
+impl<T, S, M, Extension>
+    AbstractInstruction<
+        S,
+        M,
+        Extension,
+        ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>,
+    > for MLOAD
 where
     T: Default + Clone,
     S: Stack<StackVal = T>,
     M: ReadOnlyMem<Index = T, MemVal = T>,
     Extension: EnvExtension,
-    C: Into<Constraint<C>>,
 {
     fn exec(
         &self,
         stack: &S,
         memory: &M,
         _ext: &Extension,
-    ) -> InstructionResult<AbstractExecRecord<S, M, Extension::DiffRecordType, C>> {
+    ) -> InstructionResult<ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>> {
         let mut change_log = AbstractExecRecord::default();
 
         let mem_idx: T = stack.peek(0).unwrap();
@@ -120,21 +138,25 @@ where
 
 pub struct MSTORE;
 
-impl<T, S, M, Extension, ReturnRecord, C> AbstractInstruction<S, M, Extension, ReturnRecord, C>
-    for MSTORE
+impl<T, S, M, Extension>
+    AbstractInstruction<
+        S,
+        M,
+        Extension,
+        ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>,
+    > for MSTORE
 where
     T: Clone,
     S: Stack<StackVal = T>,
     M: WriteableMem<Index = T, MemVal = T>,
     Extension: EnvExtension,
-    C: Into<Constraint<C>>,
 {
     fn exec(
         &self,
         stack: &S,
         _memory: &M,
         _ext: &Extension,
-    ) -> InstructionResult<AbstractExecRecord<S, M, Extension::DiffRecordType, C>> {
+    ) -> InstructionResult<ConcreteAbstractExecRecord<S, M, Extension::DiffRecordType>> {
         let mut change_log = AbstractExecRecord::default();
 
         let mem_idx: T = stack.peek(0).unwrap();

--- a/contrib/tests/simple_lang.rs
+++ b/contrib/tests/simple_lang.rs
@@ -27,6 +27,7 @@ pub enum Instruction<T> {
     STOP,
 }
 
+#[derive(Clone)]
 pub struct DummyExtEnv {}
 
 impl EnvExtension for DummyExtEnv {
@@ -68,7 +69,7 @@ impl Into<Constraint<DummyConstraint>> for DummyConstraint {
 
 #[allow(dead_code)]
 type SimpleLangRecord =
-    AbstractExecRecord<BaseStack<u64>, BaseMemoryConcreteUint64, DummyExtEnvRecord, u64>;
+    ConcreteAbstractExecRecord<BaseStack<u64>, BaseMemoryConcreteUint64, DummyExtEnvRecord>;
 
 // impl AbstractInstruction for Instruction<ValInt> {
 //     type Stack;
@@ -91,8 +92,7 @@ impl
         BaseStack<u64>,
         BaseMemoryConcreteUint64,
         DummyExtEnv,
-        DummyExtEnvRecord,
-        DummyConstraint,
+        ConcreteAbstractExecRecord<BaseStack<u64>, BaseMemoryConcreteUint64, DummyExtEnvRecord>,
     > for Instruction<u64>
 {
     fn exec(
@@ -101,12 +101,7 @@ impl
         _mem: &BaseMemoryConcreteUint64,
         _ext: &DummyExtEnv,
     ) -> InstructionResult<
-        AbstractExecRecord<
-            BaseStack<u64>,
-            BaseMemoryConcreteUint64,
-            DummyExtEnvRecord,
-            DummyConstraint,
-        >,
+        ConcreteAbstractExecRecord<BaseStack<u64>, BaseMemoryConcreteUint64, DummyExtEnvRecord>,
     > {
         #[allow(unreachable_code)]
         Ok(AbstractExecRecord {

--- a/core/src/machine/abstract.rs
+++ b/core/src/machine/abstract.rs
@@ -1,232 +1,108 @@
-// use crate::{instructions::{AbstractInstruction, InstructionResult, error::InstructionError, EnvExtension, EnvExtensionRecord}, stack::Stack, constraint::{Solver, self, SatResult}};
-// use crate::memory::{RWMem, ReadOnlyMem};
-// use crate::constraint::{CmpType, Constraint};
-// use thiserror::Error;
+use crate::{
+    instructions::{EnvExtension, EnvExtensionRecord},
+    memory::{Mem, MemRecord, WriteableMem},
+    stack::{Stack, StackRecord},
+};
 
-// #[derive(Error, Debug)]
-// pub enum AbstractMachineError {
-//     #[error(transparent)]
-//     InstructionError(#[from] InstructionError),
-// }
+#[derive(Clone)]
+pub struct AbstractMachine<'a, S, M, E, I>
+where
+    S: Stack,
+    M: Mem,
+    E: EnvExtension,
+{
+    pub stack: S,
+    pub mem: M,
+    pub custom_env: E,
+    pub pc: Option<usize>,
+    pub pgm: &'a [I],
+}
 
-// pub type MachineResult<T> = Result<T, AbstractMachineError>;
-// pub struct AbstractExecBranch<IType, T>
-// where IType: AbstractInstruction
-// {
-//     pub l: Option<AbstractMachine<IType>>,
-//     pub r: Option<AbstractMachine<IType>>,
-//     pub l_constraints: Vec<Constraint<T>>,
-//     pub r_constraints: Vec<Constraint<T>>,
-// }
+// NOTE(will): For some reason, calling `.clone` directly on
+// `AbstractMachine` requires that `I` implement `Clone`. `I` is behind
+// a reference and shouldn't have to implement clone in order to clone
+// `AbstractMachine`
+impl<'a, S, M, E, I> AbstractMachine<'a, S, M, E, I>
+where
+    S: Stack,
+    M: WriteableMem,
+    E: EnvExtension,
+{
+    pub fn xclone(&self) -> Self {
+        AbstractMachine {
+            stack: self.stack.clone(),
+            mem: self.mem.clone(),
+            custom_env: self.custom_env.clone(),
+            pc: self.pc.clone(),
+            pgm: self.pgm,
+        }
+    }
 
-// impl<IType, T> AbstractExecBranch<IType, T>
-// where IType: AbstractInstruction
-// {
-//     pub fn flatten(self) -> (Option<SingleBranch<IType, T>>, Option<SingleBranch<IType, T>>) {
-//         let left = {
-//             if let Some(l) = self.l {
-//                 Some((l, self.l_constraints))
-//             } else {
-//                 None
-//             }
-//         };
-//         let right = {
-//             if let Some(r) = self.r {
-//                 Some((r, self.r_constraints))
-//             } else {
-//                 None
-//             }
-//         };
-//         (left, right)
-//     }
-// }
+    pub fn apply(
+        self,
+        stack_diff: Option<StackRecord<S>>,
+        mem_diff: Option<MemRecord<M>>,
+        ext_diff: Option<E::DiffRecordType>,
+        pc_change: Option<usize>,
+        halt: bool,
+    ) -> Self {
+        let mut stack = self.stack;
+        let mut mem = self.mem;
+        let mut ext = self.custom_env;
 
-// impl<I,T> From<SingleBranch<I, T>> for AbstractExecBranch<I, T>
-// where I: AbstractInstruction
-// {
-//     fn from(b: SingleBranch<I, T>) -> Self {
-//         Self {
-//             l: Some(b.0),
-//             r: None,
-//             l_constraints: b.1,
-//             r_constraints: vec![],
-//         }
-//     }
-// }
+        stack = {
+            if let Some(stack_diff) = stack_diff {
+                stack_diff.apply(stack).unwrap()
+            } else {
+                stack
+            }
+        };
 
-// pub type SingleBranch<I: AbstractInstruction, T> = (AbstractMachine<I>, Vec<Constraint<T>>);
+        mem = {
+            if let Some(mem_diff) = mem_diff {
+                mem_diff.apply(mem).unwrap()
+            } else {
+                mem
+            }
+        };
 
-// #[derive(Default)]
-// pub struct PathSummary<IType, T, M>
-// where IType: AbstractInstruction
-// {
-//     pub reachable: Vec<(SingleBranch<IType, T>, SatResult<M>)>,
-//     pub unreachable: Vec<(SingleBranch<IType, T>, SatResult<M>)>
-// }
-// #[derive(Clone)]
-// pub struct AbstractMachine<IType: AbstractInstruction> {
-//     pub pgm: Vec<IType>,
-//     pub stack: IType::Stack,
-//     pub mem: IType::Mem,
-//     pub custom_env: IType::Extension,
-//     pub pc: usize,
+        ext = {
+            if let Some(ext_diff) = ext_diff {
+                ext_diff.apply(ext).unwrap()
+            } else {
+                ext
+            }
+        };
 
-// }
+        let pc = if halt {
+            None
+        } else {
+            match pc_change {
+                Some(pc_change) => Some(pc_change),
+                None => Some(self.pc.unwrap() + 1),
+            }
+        };
 
-// impl<I, S, M, SVal, MIdx, MVal, Ext> AbstractMachine<I>
-// where
-//     SVal: Into<MIdx> + Into<MVal>,
-//     S: Stack<StackVal = SVal> + Clone,
-//     M: RWMem + ReadOnlyMem<MemVal = MVal, Index = MIdx> + Clone,
-//     Ext: EnvExtension + Clone,
-//     I: AbstractInstruction<Stack = S, Mem = M, Extension = Ext> + Clone,
-// {
+        AbstractMachine {
+            stack,
+            mem,
+            custom_env: ext,
+            pc,
+            pgm: self.pgm,
+        }
+    }
+}
 
-//     pub fn new(stack: S, mem: M, custom_env: Ext, pgm: Vec<I>, pc: usize) -> Self {
-//         Self {
-//             pgm,
-//             stack,
-//             mem,
-//             custom_env,
-//             pc,
-//         }
-//     }
-//     pub fn exec<C: Into<Constraint<C>> + Clone, G, Ast, CS: Solver<C, Ast, G>>(&self, solver: Option<CS>) -> MachineResult<PathSummary<I, C, CS::Model>> {
-
-//         let execute = |pc: usize, pgm: &Vec<I>, mut stack:S, mut mem: M, mut ext: Ext | -> AbstractExecBranch< I, C> {
-
-//             for i in &pgm[pc..] {
-//                 let ret = i.exec::<C>(&self.stack,&self.mem, &self.custom_env).unwrap();
-//                 if ret.halt || pc == pgm.len() {
-//                     return AbstractExecBranch {
-//                         l: None,
-//                         r: None,
-//                         l_constraints: vec![],
-//                         r_constraints: vec![]
-//                     };
-//                 }
-
-//                 stack =  {
-//                     if let Some(stack_diff) = ret.stack_diff {
-//                         stack_diff.apply(stack).unwrap()
-//                     } else {
-//                         stack
-//                     }
-//                 };
-
-//                 mem = {
-//                     if let Some(mem_diff) = ret.mem_diff {
-//                         mem_diff.apply(mem).unwrap()
-//                     } else {
-//                         mem
-//                     }
-//                 };
-
-//                 ext = {
-//                     if let Some(ext_diff) = ret.ext_diff {
-//                         ext_diff.apply(ext).unwrap()
-//                     } else {
-//                         ext
-//                     }
-//                 };
-
-//                 let mut continuation_branch = AbstractExecBranch {
-//                     l: Some(Self::new(stack.clone(), mem.clone(), ext.clone(), pgm.clone(), pc + 1)),
-//                     r: None,
-//                     l_constraints: vec![],
-//                     r_constraints: vec![]
-//                 };
-
-//                 if let Some(constraints) = ret.constraints {
-//                     if let Some(c) = constraints.first() {
-//                         continuation_branch.l_constraints = c.clone();
-//                     }
-
-//                     if let Some(c) = constraints.get(1) {
-//                         continuation_branch.r_constraints = c.clone();
-//                         // Can unrwap pc_change on right side since it will be a jump of some form
-//                         continuation_branch.r = Some(Self::new(stack.clone(), mem.clone(), ext.clone(), pgm.clone(), ret.pc_change.unwrap()));
-//                     }
-//                 }
-
-//                 return continuation_branch;
-
-//             }
-//             AbstractExecBranch {
-//                 l: None,
-//                 r: None,
-
-//                 l_constraints:vec![],
-//                 r_constraints: vec![],
-//             }
-//         };
-//         let mut trace_tree: Vec<AbstractExecBranch< I, C>> = vec![];
-//         let init_branch: AbstractExecBranch<I, C> = AbstractExecBranch {
-//             l: Some(self.clone()),
-//             r: None,
-
-//             l_constraints:vec![],
-//             r_constraints: vec![],
-//         };
-//         trace_tree.push(init_branch);
-//         let mut leaves: Vec<SingleBranch<I, C>> = vec![];
-
-//         loop {
-//             let start_branch = trace_tree.pop();
-//             if let Some(start_branch) = start_branch {
-//                 if let Some(mach) = start_branch.l {
-//                     let AbstractMachine { pgm, stack, mem, custom_env, pc } = &mach;
-//                     let mut constraints = start_branch.l_constraints;
-//                     let branches = execute(pc.clone(), pgm, stack.clone(), mem.clone(), custom_env.clone());
-//                     match branches.flatten() {
-//                         (None, None) => {
-//                             leaves.push((mach, constraints));
-//                         },
-//                         (None, Some(_)) => {
-//                             panic!("This should never happen");
-//                         },
-//                         (Some(b), None) => {
-//                             constraints.extend(b.1);
-//                             trace_tree.push((b.0, constraints.clone()).into());
-//                         },
-//                         (Some(l), Some(r)) => {
-//                             let mut r_constraints = constraints.clone();
-//                             r_constraints.extend(r.1);
-//                             constraints.extend(l.1);
-//                             trace_tree.push(AbstractExecBranch {
-//                                 l: Some(l.0),
-//                                 r: Some(r.0),
-//                                 l_constraints: constraints.clone(),
-//                                 r_constraints
-//                             });
-//                         },
-//                     }
-//                 }
-//             } else {
-//                 break;
-//             }
-//         }
-
-//         let mut summary = PathSummary {
-//             reachable: vec![],
-//             unreachable: vec![]
-//         };
-//         if let Some(mut solver) = solver {
-//             for leaf in leaves {
-
-//                 let constraints = &leaf.1;
-//                 for constraint in constraints {
-//                     solver.generic_assert(constraint);
-//                 }
-//                 let sat = solver.solve();
-//                 if let SatResult::Sat(m) = sat {
-//                     summary.reachable.push((leaf, SatResult::Sat(m)));
-//                 } else {
-//                     summary.unreachable.push((leaf, SatResult::Unsat));
-//                 }
-//             }
-//         }
-
-//         Ok(summary)
-//     }
-// }
+impl<'a, S, M, E, I> AbstractMachine<'a, S, M, E, I>
+where
+    S: Stack,
+    M: Mem,
+    E: EnvExtension,
+{
+    pub fn can_continue(&self) -> bool {
+        match self.pc {
+            Some(pc) => pc < self.pgm.len(),
+            None => false,
+        }
+    }
+}

--- a/core/src/machine/error.rs
+++ b/core/src/machine/error.rs
@@ -1,4 +1,9 @@
 use thiserror::{self, Error};
 
+use crate::instructions::error::InstructionError;
+
 #[derive(Debug, Error)]
-pub enum MachineError {}
+pub enum MachineError {
+    #[error(transparent)]
+    InstructionError(#[from] InstructionError),
+}

--- a/core/src/machine/inner_interpreter.rs
+++ b/core/src/machine/inner_interpreter.rs
@@ -1,0 +1,110 @@
+use crate::{
+    constraint::Constraint,
+    instructions::{
+        AbstractExecRecord, AbstractInstruction, ConcreteAbstractExecRecord, EnvExtension,
+    },
+    memory::{Mem, WriteableMem},
+    stack::Stack,
+};
+
+use super::{r#abstract::AbstractMachine, MachineResult};
+
+pub trait InnerInterpreter<'a, S, M, E, I, InstructionStepResult, InterpreterStepResult>
+where
+    S: Stack,
+    M: Mem,
+    E: EnvExtension,
+    I: AbstractInstruction<S, M, E, InstructionStepResult>,
+{
+    fn step(&self, m: AbstractMachine<'a, S, M, E, I>) -> MachineResult<InterpreterStepResult>;
+}
+
+pub struct ConcreteInnerInterpreter {}
+
+impl<'a, S, M, E, I>
+    InnerInterpreter<
+        'a,
+        S,
+        M,
+        E,
+        I,
+        ConcreteAbstractExecRecord<S, M, E::DiffRecordType>,
+        AbstractMachine<'a, S, M, E, I>,
+    > for ConcreteInnerInterpreter
+where
+    S: Stack,
+    M: WriteableMem,
+    E: EnvExtension,
+    I: AbstractInstruction<S, M, E, ConcreteAbstractExecRecord<S, M, E::DiffRecordType>>,
+{
+    fn step(
+        &self,
+        m: AbstractMachine<'a, S, M, E, I>,
+    ) -> MachineResult<AbstractMachine<'a, S, M, E, I>> {
+        let i = m.pgm.get(m.pc.unwrap()).unwrap();
+
+        let exec_record = i.exec(&m.stack, &m.mem, &m.custom_env)?;
+
+        Ok(m.apply(
+            exec_record.stack_diff,
+            exec_record.mem_diff,
+            exec_record.ext_diff,
+            exec_record.pc_change,
+            exec_record.halt,
+        ))
+    }
+}
+
+pub type AbstractExecBranch<'a, S, M, E, I, C> = Vec<SingleBranch<'a, S, M, E, I, C>>;
+
+pub type SingleBranch<'a, S, M, E, I, C> = (AbstractMachine<'a, S, M, E, I>, Vec<Constraint<C>>);
+
+pub struct SymbolicInnerInterpreter {}
+
+impl<'a, S, M, E, I, C>
+    InnerInterpreter<
+        'a,
+        S,
+        M,
+        E,
+        I,
+        Vec<AbstractExecRecord<S, M, E::DiffRecordType, C>>,
+        AbstractExecBranch<'a, S, M, E, I, C>,
+    > for SymbolicInnerInterpreter
+where
+    S: Stack,
+    M: WriteableMem,
+    E: EnvExtension,
+    I: AbstractInstruction<S, M, E, Vec<AbstractExecRecord<S, M, E::DiffRecordType, C>>>,
+{
+    fn step(
+        &self,
+        m: AbstractMachine<'a, S, M, E, I>,
+    ) -> MachineResult<AbstractExecBranch<'a, S, M, E, I, C>> {
+        let pgm = m.pgm;
+        let pc = m.pc.unwrap();
+
+        let i = pgm.get(pc).unwrap();
+
+        let exec_records = i.exec(&m.stack, &m.mem, &m.custom_env)?;
+
+        let rv = exec_records
+            .into_iter()
+            .map(|exec_record| {
+                let constraints = exec_record.constraints.unwrap_or(vec![]);
+
+                let new_machine = m.xclone().apply(
+                    exec_record.stack_diff,
+                    exec_record.mem_diff,
+                    exec_record.ext_diff,
+                    exec_record.pc_change,
+                    exec_record.halt,
+                );
+
+                (new_machine, constraints)
+            })
+            .collect();
+
+        Ok(rv)
+    }
+}

--- a/core/src/machine/mod.rs
+++ b/core/src/machine/mod.rs
@@ -1,5 +1,8 @@
 pub mod r#abstract;
 pub mod error;
+mod inner_interpreter;
+mod outer_interpreter;
+
 use std::rc::Rc;
 
 use crate::instructions::*;

--- a/core/src/machine/outer_interpreter.rs
+++ b/core/src/machine/outer_interpreter.rs
@@ -1,0 +1,159 @@
+use crate::{
+    constraint::Constraint,
+    instructions::{AbstractInstruction, EnvExtension},
+    memory::{Mem, WriteableMem},
+    stack::Stack,
+};
+
+use super::{
+    inner_interpreter::{AbstractExecBranch, InnerInterpreter},
+    r#abstract::AbstractMachine,
+    MachineResult,
+};
+
+pub trait OuterInterpreter<Output, M> {
+    fn run(&self, m: M) -> MachineResult<Output>;
+}
+
+pub struct ConcreteOuterInterpreter<'a, S, M, E, I, InstructionStepResult, InterpreterStepResult>
+where
+    S: Stack,
+    M: Mem,
+    E: EnvExtension,
+    I: AbstractInstruction<S, M, E, InstructionStepResult>,
+{
+    inner_interpreter:
+        dyn InnerInterpreter<'a, S, M, E, I, InstructionStepResult, InterpreterStepResult>,
+}
+
+impl<'a, S, M, E, I, InstructionStepResult>
+    OuterInterpreter<AbstractMachine<'a, S, M, E, I>, AbstractMachine<'a, S, M, E, I>>
+    for ConcreteOuterInterpreter<
+        'a,
+        S,
+        M,
+        E,
+        I,
+        InstructionStepResult,
+        AbstractMachine<'a, S, M, E, I>,
+    >
+where
+    S: Stack,
+    M: WriteableMem,
+    E: EnvExtension,
+    I: AbstractInstruction<S, M, E, InstructionStepResult>,
+{
+    fn run(
+        &self,
+        m: AbstractMachine<'a, S, M, E, I>,
+    ) -> MachineResult<AbstractMachine<'a, S, M, E, I>> {
+        let mut x = m;
+
+        while x.can_continue() {
+            x = self.inner_interpreter.step(x)?;
+        }
+
+        Ok(x)
+    }
+}
+
+pub struct SymbolicOuterInterpreter<'a, S, M, E, I, InstructionStepResult, InterpreterStepResult>
+where
+    S: Stack,
+    M: Mem,
+    E: EnvExtension,
+    I: AbstractInstruction<S, M, E, InstructionStepResult>,
+{
+    inner_interpreter:
+        dyn InnerInterpreter<'a, S, M, E, I, InstructionStepResult, InterpreterStepResult>,
+}
+
+pub type SingleBranch<'a, S, M, E, I, C> = (AbstractMachine<'a, S, M, E, I>, Vec<Constraint<C>>);
+
+impl<'a, S, M, E, I, InstructionStepResult, C>
+    OuterInterpreter<Vec<SingleBranch<'a, S, M, E, I, C>>, AbstractMachine<'a, S, M, E, I>>
+    for SymbolicOuterInterpreter<
+        'a,
+        S,
+        M,
+        E,
+        I,
+        InstructionStepResult,
+        AbstractExecBranch<'a, S, M, E, I, C>,
+    >
+where
+    S: Stack,
+    M: WriteableMem,
+    E: EnvExtension,
+    I: AbstractInstruction<S, M, E, InstructionStepResult>,
+    C: Clone,
+{
+    fn run(
+        &self,
+        m: AbstractMachine<'a, S, M, E, I>,
+    ) -> MachineResult<Vec<SingleBranch<'a, S, M, E, I, C>>> {
+        let mut trace_tree: Vec<SingleBranch<'a, S, M, E, I, C>> = vec![(m, vec![])];
+
+        let mut leaves: Vec<SingleBranch<'a, S, M, E, I, C>> = vec![];
+
+        loop {
+            let start_branch = trace_tree.pop();
+            if let Some((mach, constraints)) = start_branch {
+                if mach.can_continue() {
+                    let new_machines = self.inner_interpreter.step(mach)?;
+
+                    new_machines
+                        .into_iter()
+                        .for_each(|(new_mach, constraints_to_add)| {
+                            let mut new_constraints: Vec<Constraint<C>> = constraints.clone();
+                            new_constraints.extend(constraints_to_add);
+                            trace_tree.push((new_mach, new_constraints));
+                        });
+                } else {
+                    leaves.push((mach, constraints));
+                }
+            } else {
+                break;
+            }
+        }
+
+        Ok(leaves)
+
+        // TODO(will) - This doesn't include the `PathSummary` portion yet where we use the solver
+        // to find the reachable paths and return models. The type signature of `ConcreteOuterInterpreter` is already incredibly
+        // complex and I'd prefer to not add the additional generics that the solver is going to entail
+        // in a separate PR.
+        //
+        // NOTE(will) - This type signature will have to change
+        //          #[derive(Default)]
+        //          pub struct PathSummary<IType, T, M>
+        //          where
+        //              IType: AbstractInstruction,
+        //          {
+        //              pub reachable: Vec<(SingleBranch<IType, T>, SatResult<M>)>,
+        //              pub unreachable: Vec<(SingleBranch<IType, T>, SatResult<M>)>,
+        //          }
+        //
+        //         let mut summary = PathSummary {
+        //             reachable: vec![],
+        //             unreachable: vec![],
+        //         };
+
+        //         if let Some(mut solver) = solver {
+        //             for leaf in leaves {
+        //                 let constraints = &leaf.1;
+        //                 for constraint in constraints {
+        //                     solver.generic_assert(constraint);
+        //                 }
+        //                 let sat = solver.solve();
+        //                 if let SatResult::Sat(m) = sat {
+        //                     summary.reachable.push((leaf, SatResult::Sat(m)));
+        //                 } else {
+        //                     summary.unreachable.push((leaf, SatResult::Unsat));
+        //                 }
+        //             }
+        //         }
+
+        //         Ok(summary)
+    }
+}

--- a/core/src/memory/memory_models.rs
+++ b/core/src/memory/memory_models.rs
@@ -40,7 +40,7 @@ pub type BaseMemoryConcreteUint64 = BaseMemoryConcreteIndex<u64>;
 
 impl<'a, I> Mem for BaseMemorySymbolicArray<'a, I, BV<'a>>
 where
-    I: z3::ast::Ast<'a>,
+    I: z3::ast::Ast<'a> + Clone,
 {
     type MemVal = BV<'a>;
 
@@ -49,7 +49,7 @@ where
 
 impl<'a, I> ReadOnlyMem for BaseMemorySymbolicArray<'a, I, BV<'a>>
 where
-    I: z3::ast::Ast<'a>,
+    I: z3::ast::Ast<'a> + Clone,
 {
     fn read(&self, idx: Self::Index) -> super::MemoryResult<Option<Self::MemVal>> {
         Ok(self._inner.select(&idx).as_bv())
@@ -58,7 +58,7 @@ where
 
 impl<'a, I> WriteableMem for BaseMemorySymbolicArray<'a, I, BV<'a>>
 where
-    I: z3::ast::Ast<'a>,
+    I: z3::ast::Ast<'a> + Clone,
 {
     fn write(&self, idx: Self::Index, val: Self::MemVal) -> super::MemoryResult<Self> {
         Ok(Self {

--- a/core/src/memory/mod.rs
+++ b/core/src/memory/mod.rs
@@ -6,7 +6,7 @@ pub mod symbolic_bv;
 
 use error::MemoryError;
 
-pub trait Mem: Sized {
+pub trait Mem: Sized + Clone {
     type MemVal;
     type Index;
 }

--- a/core/src/stack/mod.rs
+++ b/core/src/stack/mod.rs
@@ -1,7 +1,9 @@
 pub mod error;
 use error::StackError;
+
 pub type StackResult<T> = Result<T, StackError>;
-pub trait Stack: Sized {
+
+pub trait Stack: Sized + Clone {
     type StackVal;
     fn push<V: Into<Self::StackVal>>(&self, v: V) -> StackResult<Self>;
     fn pop(&self) -> StackResult<Self>;


### PR DESCRIPTION
…Machine into AbstractMachine, InnerInterpreter, and OuterInterpreter

Made return type for AbstractInstruction abstract.

Because instructions can now return different types, the `InnerInterpreter` trait constrains the set of possible return types from individual instructions.
All existing instructions still return `AbstractExecRecord`. All existing instructions are concrete so they return `ConcreteAbstractExecRecord` which has its constraint type parameter set to the unit type. This allows concrete instructions to not have any generic type for constraints while still using the same `AbstractExecRecord` return type.

Separated AbstractMachine into AbstractMachine, InnerInterpreter, and OuterInterpreter.

AbstractMachine - purely encapsulates the current state of the machine. It does not include constraints as concrete machines do not have constraints.

InnerInterpreter - handles the return value and state update from execution of an individual instruction. We have two example inner interpreters. The concrete inner interpreter simply updates the current machine state. The symbolic inner interpreter returns a vec of new machine states and constraints.

OuterInterpreter - handles orchestration of which machine state(s) to run. For the example outer interpreters we implement, we embed the inner interpreter in the outer interpreter struct as a trait object. This allows for some flexibility in choosing different inner interpreters so long as they have a  step function of the right type for the outer interpreter. The concrete outer interpreter just steps the concrete inner interpreter until the machine can’t execute any further. The symbolic outer interpreter performs DFS on the search graph of machine states. Note that this architecture allows us to substitute out an alternative symbolic outer interpreter that performs BFS or any other alternative search strategy.

I temporarily removed the `PathSummary` portion yet where we use the solver to find the reachable paths and return models. The type signature of `SymbolicOuterInterpreter` is already incredibly complex and I'd prefer to not add the additional generics that the solver is going to entail in a separate PR.